### PR TITLE
Spatial standards - review by JN

### DIFF
--- a/standards/spatial.Rmd
+++ b/standards/spatial.Rmd
@@ -315,7 +315,7 @@ project](https://github.com/ropenscilabs/statistical-software-review).
   user control over neighbourhood forms and sizes. In particular:*
     - **SP3.0a** *Neighbours (able to be expressed) on regular grids should be
       able to be considered in both rectangular only, or rectangular and
-      diagonal (respectively "rook" and "queen" by analogy to chess.*
+      diagonal (respectively "rook" and "queen" by analogy to chess).*
     - **SP3.0b** *Neighbourhoods in irregular spaces should be minimally able
       to be controlled via an integer number of neighbours, an area (or
       equivalent distance defining an area) in which to include neighbours, or

--- a/standards/spatial.Rmd
+++ b/standards/spatial.Rmd
@@ -177,10 +177,10 @@ reference systems used to precisely relate pairs of coordinates to precise
 locations in a curvilinear space, and in particular to the Earth's ellipsoid,
 need to be able to be compared and transformed regardless of the specificities
 of individual software. This ubiquitous need has fostered the development of
-the [`proj` library](https://proj.org/) for representing and transforming
+the [`PROJ` library](https://proj.org/) for representing and transforming
 spatial coordinates. Several other libraries have been built on top or or
 alongside that, notably including the [`GDAL` ("Geospatial Data Abstraction
-Library")](https://gdal.org) and [`geos` ("Geometry Engine, Open
+Library")](https://gdal.org) and [`GEOS` ("Geometry Engine, Open
 Source")](https://trac.osgeo.org/geos/) libraries. These libraries are used by,
 and integrated within, most geographical spatial software commonly used today,
 and will likely continue to be used.
@@ -236,9 +236,9 @@ documentation and testing.
 
 As described above, one of the primary reasons for the development of classes
 in Spatial Software is to represent the coordinate reference systems in which
-data are represented, and to ensure compatibility with the [`proj`
+data are represented, and to ensure compatibility with the [`PROJ`
 system](https://proj.org/) and other generic spatial libraries. The
-[`proj`](https://proj.org/) standards and associated software library have been
+[`PROJ`](https://proj.org/) standards and associated software library have been
 recently (2020) updated (to version number 7) with "breaking changes" that are
 not backwards-compatible with previous versions, and in particular with the
 long-standing version 4. The details and implications of these changes within
@@ -256,7 +256,7 @@ The following standard applies to software which directly or indirectly relies
 on geographic data which uses or relies upon coordinate reference systems.
 
 - **SP2.3** *Geographical Spatial Software should be compliant with version 6
-  (and, ideally 7) of* [`proj`](https://proj.org/), *and with* `wkt2`
+  (and, ideally 7) of* [`PROJ`](https://proj.org/), *and with* `wkt2`
   *representations. The primary implications, described in detail in the articles
   linked to above, are that:*
     - **SP2.3a** *Software should not accept so-called "PROJ4-strings"


### PR DESCRIPTION
Hi @mpadge,
I read the spatial standards section and added some tiny changes to the text. I also have some comments:

1. I found some standards to be too strict or limiting. I assume that these standards should be considered as technical standards / best practices, rather than research limitations... 
I think changing from "should" to "should consider" could be an improvement.
For example:
- *"SP2.4a Software should provide an ability to convert objects in any new class systems into representations of pre-existing classes such as those listed above."* - I would assume some new class systems could be just used to store non-spatial results. What then?
- *"SP3.1 Spatial software which considers spatial neighbours should enable neighbour contributions to be weighted by distance (or other weighting variable), and not rely on a uniform-weight rectangular cut-off."* - I assume some algorithms which consider spatial neighbours could make no sense when weighting by distance (e.g., categorical variables, use of dissimilarity measures, ...).
- *"SP3.3 Spatial regression software should explicitly quantify and distinguish autocovariant or autoregressive processes from those covariant or regressive processes not directly related to spatial structure alone."* - I do not know if it is always possible...
- *"SP4.1 Any units included as attributes of input data should also be included within return values."* - Let's say that input data has 10 variables (attributes) with different units. The used algorithm does not use any of the attributes (maybe it just uses coordinates) - so why should it include all the units in the output? Return of the units should be done only when the units are important in calculations... I also have a similar impression of *"SP2.9 The pre-processing function described above should maintain all metadata attributes of input data."*. 
- *"SP5.0 Implement default plot methods for any implemented class system."* - Even when the class system does not store spatial data anymore (e.g., calculating spatial metrics)? 
- *"SP5.3 Offer an ability to generate interactive (generally html-based) visualisations of results."* - It is similar to my previous point, but also interactive visualizations could not be possible (or just not suitable) for large spatial datasets (e.g., tens of millions of raster cells).

2. Two standards seem to be better served by PROJ than routines in R packages:
- *"SP2.3b Documentation should explicitly clarify whether, and under which conditions, geographical coordinates are expected to be longitude-latitude or latitude-longitude."* - I think PROJ should take care of it, as the order depends on the projection (?).
- *"SP6.0 Software which implements routines for transforming coordinates of input data should include tests which demonstrate ability to recover the original coordinates."* - Isn't that the role of PROJ?

3. *"The latter standard, SP3.6, is commonly met by applying some form of spatial partitioning to data, and using spatially distinct partitions to define test and training data."* - I think some references could be added to this standard (e.g., https://geocompr.robinlovelace.net/spatial-cv.html, https://doi.org/10.1109/IGARSS.2012.6352393, https://www.sciencedirect.com/science/article/abs/pii/S0304380019302145, https://besjournals.onlinelibrary.wiley.com/doi/full/10.1111/2041-210X.13107)

4. What does "Testing" mean in 5.9? 
5. 5.9: *"Return the result of that algorithmic application"* - in my opinion, it is obvious that an analytic algorithm will return the result. Maybe this point is not necessary?
6. *"Many developers of spatial software in R, including those responsible for the CRAN Task view on “Analysis of Spatial Data”,"* - what do you mean in the second part of this sentence? Roger is the only person "responsible" for this task view... How about "Many spatial software in R, including those featured in the CRAN Task view on “Analysis of Spatial Data”"?
7. I do not understand the following standard: *"SP3.2 Spatial software which relies on sampling from input data (even if only of spatial coordinates) should enable sampling procedures to be based on local spatial densities of those input data."*
8. I also think it would be good to inform/ask for feedback from other #rspatial developers, for example, by opening a new issue at https://github.com/r-spatial/discuss/issues.
9. Code/data examples are not part of the spatial standards, but maybe they should be? Quality examples/documentation/vignettes are vital for users. I also think that, in most cases, example data should be stored in spatial data formats rather than R objects (of some class). 
10. I often see some new R packages that extend existing R packages (and thus could be great together), however they use different standards (different function naming, arguments' names and order, output structures, etc.). I think it could be useful if developers should list similar (related) packages during the review process and explain why they decided on using different standards (if applicable).

I hope that, at least, some of my comments make sense and could be useful in this project.
Best,
Jakub